### PR TITLE
further encapsulated zamboni, workflow params as a map of strings or list of strings

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiFormats.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiFormats.scala
@@ -1,34 +1,23 @@
 package org.broadinstitute.dsde.snoop.ws
 
-import spray.json.DefaultJsonProtocol
+import org.broadinstitute.dsde.snoop.ws.WorkflowParameter.WorkflowParameter
+import spray.json._
 
-class SnoopApiFormats {
-  
+object WorkflowParameter {
+  type WorkflowParameter = Either[String, Seq[String]]
+
+  def apply(value: String): WorkflowParameter = Left(value)
+  def apply(array: Seq[String]): WorkflowParameter = Right(array)
 }
 
 case class WorkflowExecution(
     id: Option[String], 
-    workflowParameters: Map[String, String],
+    workflowParameters: Map[String, WorkflowParameter],
     workflowId: String, 
     callbackUri: String,
-    status: Option[String])
-
-case class ZamboniWorkflow(
-    Zamboni: Map[String, String],
-    workflow: Map[String, String])
-
-case class ZamboniSubmission(
-    authToken: String,
-    requestString: String)
-
-case class ZamboniSubmissionResult(
-    workflowId: String,
-    status: String)
-
+    status: Option[String]) {
+}
 
 object WorkflowExecutionJsonSupport extends DefaultJsonProtocol {
   implicit val AnalysisFormat = jsonFormat5(WorkflowExecution)
-  implicit val ZamboniSubmissionFormat = jsonFormat2(ZamboniSubmission)
-  implicit val ZamboniSubmissionResultFormat = jsonFormat2(ZamboniSubmissionResult)
-  implicit val ZamboniWorkflowFormat = jsonFormat2(ZamboniWorkflow)
 }

--- a/src/test/scala/org/broadinstitute/dsde/snoop/SnoopApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/snoop/SnoopApiServiceSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.snoop
 
-import org.broadinstitute.dsde.snoop.ws.{WorkflowExecutionJsonSupport, ZamboniSubmissionResult}
+import org.broadinstitute.dsde.snoop.ws.WorkflowParameter.WorkflowParameter
+import org.broadinstitute.dsde.snoop.ws._
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import spray.httpx.SprayJsonSupport
@@ -11,12 +12,8 @@ import SprayJsonSupport._
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import spray.testkit.ScalatestRouteTest
-import org.broadinstitute.dsde.snoop.ws.ZamboniApi
-import org.broadinstitute.dsde.snoop.ws.ZamboniSubmission
 import scala.concurrent.Future
-import org.broadinstitute.dsde.snoop.ws.WorkflowExecution
 import spray.routing.RequestContext
-import org.broadinstitute.dsde.snoop.ws.ZamboniWorkflowExecutionService
 
 class SnoopApiServiceSpec extends FlatSpec with SnoopApiService with ScalatestRouteTest with Matchers {
   def actorRefFactory = system
@@ -29,22 +26,76 @@ class SnoopApiServiceSpec extends FlatSpec with SnoopApiService with ScalatestRo
     }
   }
 
-  "Snoop" should "return 200 for post to workflowExecution" in {
+  it should "return 200 for post to workflowExecution" in {
     Post("/workflowExecutions", HttpEntity(ContentTypes.`application/json`, s"""{
           "workflowParameters": {"para1": "v1", "p2": "v2"},
           "workflowId":  "workflow_id",
           "callbackUri": "callback"}""")) ~>
       sealRoute(snoopRoute) ~> check {
       status === OK
-      responseAs[WorkflowExecution] === WorkflowExecution(Some("f00ba4"), Map("para1" -> "v1", "p2" -> "v2"), "workflow_id", "callback", Some("SUBMITTED"))
+      responseAs[WorkflowExecution] === WorkflowExecution(Some("f00ba4"), Map("para1" -> WorkflowParameter("v1"), "p2" -> WorkflowParameter("v2"), "p3" -> WorkflowParameter(Seq("a", "b", "c"))), "workflow_id", "callback", Some("SUBMITTED"))
     }
   }
 
-  "Snoop" should "return 200 for get to workflowExecution" in {
+  it should "return 200 for get to workflowExecution" in {
     Get("/workflowExecutions/f00ba4") ~>
       sealRoute(snoopRoute) ~> check {
       status === OK
-      responseAs[WorkflowExecution] === WorkflowExecution(Some("f00ba4"), Map("para1" -> "v1", "p2" -> "v2"), "workflow_id", "callback", Some("RUNNING"))
+      responseAs[WorkflowExecution] === WorkflowExecution(Some("f00ba4"), Map("para1" -> WorkflowParameter("v1"), "p2" -> WorkflowParameter("v2")), "workflow_id", "callback", Some("RUNNING"))
+    }
+  }
+
+  "WorkflowParameter parser" should "parse a single value" in {
+    import WorkflowExecutionJsonSupport._
+    import spray.json._
+
+    val start = WorkflowParameter("foo")
+    val json = start.toJson
+    val end = json.convertTo[WorkflowParameter]
+
+    assertResult(JsString("foo")) { json }
+    assertResult(start) { end }
+  }
+
+  it should "parse a list of values" in {
+    import WorkflowExecutionJsonSupport._
+    import spray.json._
+
+    val start = WorkflowParameter(Seq("value1", "value2"))
+    val json = start.toJson
+    val end = json.convertTo[WorkflowParameter]
+
+    assertResult(JsArray(JsString("value1"), JsString("value2"))) { json }
+    assertResult(start) { end }
+  }
+
+  it should "fail to parse a number" in {
+    import WorkflowExecutionJsonSupport._
+    import spray.json._
+
+    val json = JsNumber(12)
+    intercept[DeserializationException] {
+      json.convertTo[WorkflowParameter]
+    }
+  }
+
+  it should "fail to parse a list of numbers" in {
+    import WorkflowExecutionJsonSupport._
+    import spray.json._
+
+    val json = JsArray(JsNumber(12), JsNumber(33))
+    intercept[DeserializationException] {
+      json.convertTo[WorkflowParameter]
+    }
+  }
+
+  it should "fail to parse a mixed list" in {
+    import WorkflowExecutionJsonSupport._
+    import spray.json._
+
+    val json = JsArray(JsString("foo"), JsNumber(33))
+    intercept[DeserializationException] {
+      json.convertTo[WorkflowParameter]
     }
   }
 }


### PR DESCRIPTION
moved zamboni json case classes into zamboni area
change snoop api to accept workflow params as a map of (strings or list of strings)