### PR TITLE
Swaggerize

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ libraryDependencies ++= {
     "io.spray"            %%  "spray-client"  % sprayV,
     "io.spray"            %%  "spray-json"    % "1.3.1",
     "com.typesafe.akka"   %%  "akka-actor"    % akkaV,
+    "com.gettyimages"     %%  "spray-swagger" % "0.5.0",
     "io.spray"            %%  "spray-testkit" % sprayV  % "test",
     "com.typesafe.akka"   %%  "akka-testkit"  % akkaV   % "test",
     "org.scalatest"       %%  "scalatest"     % "2.2.4" % "test"

--- a/src/main/scala/org/broadinstitute/dsde/snoop/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/Boot.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.snoop
 
 import akka.actor.{ActorSystem, Props}
 import akka.io.IO
+import com.wordnik.swagger.model.ApiInfo
 import org.broadinstitute.dsde.snoop.ws.{StandardZamboniApi, ZamboniWorkflowExecutionService}
 import spray.can.Http
 import akka.pattern.ask
@@ -10,6 +11,7 @@ import spray.routing.RequestContext
 import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 import java.io.File
+import scala.reflect.runtime.universe._
 
 object Boot extends App {
 
@@ -21,8 +23,23 @@ object Boot extends App {
   val executionServiceHandler: RequestContext => WorkflowExecutionService =
     ZamboniWorkflowExecutionService(StandardZamboniApi(conf.getString("zamboni.server")), conf.getString("workflow.sandbox"))
 
-  // create and start our service actor
-  val service = system.actorOf(SnoopApiServiceActor.props(executionServiceHandler), "snoop-service")
+  private val swaggerConfig = conf.getConfig("swagger")
+  val swaggerService = new SwaggerService(
+    swaggerConfig.getString("apiVersion"),
+    swaggerConfig.getString("baseUrl"),
+    swaggerConfig.getString("apiDocs"),
+    swaggerConfig.getString("swaggerVersion"),
+    Seq(typeOf[RootSnoopApiService], typeOf[WorkflowExecutionApiService]),
+    Option(new ApiInfo(
+      swaggerConfig.getString("info"),
+      swaggerConfig.getString("description"),
+      swaggerConfig.getString("termsOfServiceUrl"),
+      swaggerConfig.getString("contact"),
+      swaggerConfig.getString("license"),
+      swaggerConfig.getString("licenseUrl"))
+  ))
+
+  val service = system.actorOf(SnoopApiServiceActor.props(executionServiceHandler, swaggerService), "snoop-service")
 
   implicit val timeout = Timeout(5.seconds)
   // start a new HTTP server on port 8080 with our service actor as the handler

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiFormats.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiFormats.scala
@@ -2,6 +2,8 @@ package org.broadinstitute.dsde.snoop.ws
 
 import org.broadinstitute.dsde.snoop.ws.WorkflowParameter.WorkflowParameter
 import spray.json._
+import com.wordnik.swagger.annotations.{ApiModel, ApiModelProperty}
+import scala.annotation.meta.field
 
 object WorkflowParameter {
   type WorkflowParameter = Either[String, Seq[String]]
@@ -10,20 +12,17 @@ object WorkflowParameter {
   def apply(array: Seq[String]): WorkflowParameter = Right(array)
 }
 
-import com.wordnik.swagger.annotations.{ApiModel, ApiModelProperty}
-import scala.annotation.meta.field
-
 @ApiModel(value = "Start Workflow / Workflow Status Response")
 case class WorkflowExecution(
-    @(ApiModelProperty@field)(required = false, value = "The id")
+    @(ApiModelProperty@field)(required = false, value = "The id of the workflow execution. Required for all but POST requests.")
     id: Option[String], 
-    @(ApiModelProperty@field)(required = true, value = "The workflow parameters")
+    @(ApiModelProperty@field)(required = true, value = "The workflow parameters. Values may be Strings or Lists of Strings.")
     workflowParameters: Map[String, WorkflowParameter],
-    @(ApiModelProperty@field)(required = true, value = "The workflow id")
+    @(ApiModelProperty@field)(required = true, value = "The workflow id to run.")
     workflowId: String, 
-    @(ApiModelProperty@field)(required = true, value = "The callback uri")
+    @(ApiModelProperty@field)(required = true, value = "The callback uri. This URI will be POSTed to when the workflow execution completes.")
     callbackUri: String,
-    @(ApiModelProperty@field)(required = false, value = "The workflow status")
+    @(ApiModelProperty@field)(required = false, value = "The workflow status.")
     status: Option[String])
 
 object WorkflowExecutionJsonSupport extends DefaultJsonProtocol {

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiFormats.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiFormats.scala
@@ -10,13 +10,21 @@ object WorkflowParameter {
   def apply(array: Seq[String]): WorkflowParameter = Right(array)
 }
 
+import com.wordnik.swagger.annotations.{ApiModel, ApiModelProperty}
+import scala.annotation.meta.field
+
+@ApiModel(value = "Start Workflow / Workflow Status Response")
 case class WorkflowExecution(
+    @(ApiModelProperty@field)(required = false, value = "The id")
     id: Option[String], 
+    @(ApiModelProperty@field)(required = true, value = "The workflow parameters")
     workflowParameters: Map[String, WorkflowParameter],
+    @(ApiModelProperty@field)(required = true, value = "The workflow id")
     workflowId: String, 
+    @(ApiModelProperty@field)(required = true, value = "The callback uri")
     callbackUri: String,
-    status: Option[String]) {
-}
+    @(ApiModelProperty@field)(required = false, value = "The workflow status")
+    status: Option[String])
 
 object WorkflowExecutionJsonSupport extends DefaultJsonProtocol {
   implicit val AnalysisFormat = jsonFormat5(WorkflowExecution)

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiService.scala
@@ -10,6 +10,12 @@ import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
 import spray.routing.Directive.pimpApply
 import org.broadinstitute.dsde.snoop.ws._
 import akka.event.Logging
+import com.wordnik.swagger.annotations._
+import com.wordnik.swagger.model.ApiInfo
+import scala.reflect.runtime.universe._
+import com.gettyimages.spray.swagger.SwaggerHttpService
+import java.io.File
+import com.typesafe.config.{Config, ConfigFactory}
 
 object SnoopApiServiceActor {
   def props(executionServiceHandler: RequestContext => WorkflowExecutionService): Props = {
@@ -17,21 +23,54 @@ object SnoopApiServiceActor {
   }
 }
 
-class SnoopApiServiceActor(override val executionServiceHandler: RequestContext => WorkflowExecutionService) extends Actor with SnoopApiService {
+class SnoopApiServiceActor(override val executionServiceHandler: RequestContext => WorkflowExecutionService) extends Actor with BaseSnoopApiService with WorkflowExecutionApiService {
+  implicit def executionContext = actorRefFactory.dispatcher
   def actorRefFactory = context
-  def receive = runRoute(snoopRoute)
+  def possibleRoutes = baseRoute ~ workflowRoutes ~ swaggerService.routes 
+
+  def receive = runRoute(possibleRoutes)
+
+  private val snoopConfig: Config = ConfigFactory.parseFile(new File("/etc/snoop.conf"))
+  private val swaggerConfig = snoopConfig.getConfig("swagger")
+
+  val swaggerService = new SwaggerHttpService {
+    override def apiTypes = Seq(typeOf[BaseSnoopApiService], typeOf[WorkflowExecutionApiService])
+
+    override def apiVersion = swaggerConfig.getString("apiVersion")
+    override def baseUrl = swaggerConfig.getString("baseUrl")
+    override def docsPath = swaggerConfig.getString("apiDocs")
+    override def actorRefFactory = context
+    override def swaggerVersion = swaggerConfig.getString("swaggerVersion")
+
+    override def apiInfo = Some(
+      new ApiInfo(
+        swaggerConfig.getString("info"),
+        swaggerConfig.getString("description"),
+        swaggerConfig.getString("termsOfServiceUrl"),
+        swaggerConfig.getString("contact"),
+        swaggerConfig.getString("license"),
+        swaggerConfig.getString("licenseUrl"))
+    )
+  }
 }
 
-
-// this trait defines our service behavior independently from the service actor
-trait SnoopApiService extends HttpService {
-  implicit def executionContext = actorRefFactory.dispatcher
+@Api(value = "", description = "Snoop Base API", position = 1)
+trait BaseSnoopApiService extends HttpService {
   import WorkflowExecutionJsonSupport._
   import SprayJsonSupport._
 
   def executionServiceHandler: RequestContext => WorkflowExecutionService
 
-  val snoopRoute =
+  @ApiOperation(value = "Check if Snoop is alive",
+    nickname = "poke",
+    httpMethod = "GET",
+    produces = "text/html",
+    response = classOf[String])
+  @ApiResponses(Array(
+    new ApiResponse(code = 200, message = "Successful Request"),
+    new ApiResponse(code = 500, message = "Snoop Internal Error")
+  ))  
+   def baseRoute =
     path("") {
       get {
         respondWithMediaType(`text/html`) {
@@ -49,7 +88,29 @@ trait SnoopApiService extends HttpService {
       get {
         requestContext => requestContext.complete(requestContext.request.headers.mkString(",\n"))
       }
-    } ~
+    }
+}
+
+// this trait defines our service behavior independently from the service actor
+@Api(value = "workflowExecutions", description = "Snoop Workflow Execution API", position = 1)
+trait WorkflowExecutionApiService extends HttpService {
+  import WorkflowExecutionJsonSupport._
+  import SprayJsonSupport._
+
+  def executionServiceHandler: RequestContext => WorkflowExecutionService
+
+  def workflowRoutes = startWorkflowRoute ~ workflowStatusRoute
+
+  @ApiOperation(value = "Start workflow",
+    nickname = "start workflow",
+    httpMethod = "POST",
+    produces = "text/html",
+    response = classOf[WorkflowExecution])
+  @ApiResponses(Array(
+    new ApiResponse(code = 200, message = "Successful Request"),
+    new ApiResponse(code = 500, message = "Snoop Internal Error")
+  ))  
+  def startWorkflowRoute = 
     cookie("iPlanetDirectoryPro") { securityTokenCookie =>
       val securityToken = securityTokenCookie.content
       path("workflowExecutions") {
@@ -60,14 +121,32 @@ trait SnoopApiService extends HttpService {
               executionService ! WorkflowExecutionService.WorkflowStart(workflowExecution, securityToken)
           }
         }
-      } ~
-        path("workflowExecutions" / Segment) { id =>
-          respondWithMediaType(`application/json`) {
-            requestContext =>
-              val executionService = actorRefFactory.actorOf(WorkflowExecutionService.props(executionServiceHandler, requestContext))
-              executionService ! WorkflowExecutionService.WorkflowStatus(id, securityToken)
-          }
+      }
+    }
+
+  @ApiOperation(value = "Get workflow status",
+    nickname = "workflow status",
+    httpMethod = "GET",
+    produces = "application/json",
+    response = classOf[WorkflowExecution])
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "workflow id")
+  ))
+  @ApiResponses(Array(
+    new ApiResponse(code = 200, message = "successful request"),
+    new ApiResponse(code = 404, message = "workflow id not found"),
+    new ApiResponse(code = 500, message = "Snoop internal error")
+  ))  
+  def workflowStatusRoute =
+    cookie("iPlanetDirectoryPro") { securityTokenCookie =>
+      val securityToken = securityTokenCookie.content
+      path("workflowExecutions" / Segment) { id =>
+        respondWithMediaType(`application/json`) {
+          requestContext =>
+            val executionService = actorRefFactory.actorOf(WorkflowExecutionService.props(executionServiceHandler, requestContext))
+            executionService ! WorkflowExecutionService.WorkflowStatus(id, securityToken)
         }
+      }
     }
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/snoop/SnoopApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/snoop/SnoopApiServiceSpec.scala
@@ -15,13 +15,13 @@ import spray.testkit.ScalatestRouteTest
 import scala.concurrent.Future
 import spray.routing.RequestContext
 
-class SnoopApiServiceSpec extends FlatSpec with SnoopApiService with ScalatestRouteTest with Matchers {
+class SnoopApiServiceSpec extends FlatSpec with BaseSnoopApiService with WorkflowExecutionApiService with ScalatestRouteTest with Matchers {
   def actorRefFactory = system
 
   val executionServiceHandler: RequestContext => WorkflowExecutionService = ZamboniWorkflowExecutionService(MockZamboniApi, "test")
 
   "Snoop" should "return a greeting for GET requests to the root path" in {
-    Get() ~> snoopRoute ~> check {
+    Get() ~> baseRoute ~> check {
       responseAs[String] should include("Snoop web service is operational")
     }
   }
@@ -32,7 +32,7 @@ class SnoopApiServiceSpec extends FlatSpec with SnoopApiService with ScalatestRo
           "workflowId":  "workflow_id",
           "callbackUri": "callback"}""")) ~>
       addHeader(HttpHeaders.`Cookie`(HttpCookie("iPlanetDirectoryPro", "test_token"))) ~>
-      sealRoute(snoopRoute) ~>
+      sealRoute(startWorkflowRoute) ~>
       check {
       status === OK
       responseAs[WorkflowExecution] === WorkflowExecution(Some("f00ba4"), Map("para1" -> WorkflowParameter("v1"), "p2" -> WorkflowParameter("v2"), "p3" -> WorkflowParameter(Seq("a", "b", "c"))), "workflow_id", "callback", Some("SUBMITTED"))
@@ -44,7 +44,7 @@ class SnoopApiServiceSpec extends FlatSpec with SnoopApiService with ScalatestRo
           "workflowParameters": {"para1": "v1", "p2": "v2"},
           "workflowId":  "workflow_id",
           "callbackUri": "callback"}""")) ~>
-      sealRoute(snoopRoute) ~>
+      sealRoute(startWorkflowRoute) ~>
       check {
         status === BadRequest
       }
@@ -53,7 +53,7 @@ class SnoopApiServiceSpec extends FlatSpec with SnoopApiService with ScalatestRo
   it should "return 200 for get to workflowExecution" in {
     Get("/workflowExecutions/f00ba4") ~>
       addHeader(HttpHeaders.`Cookie`(HttpCookie("iPlanetDirectoryPro", "test_token"))) ~>
-      sealRoute(snoopRoute) ~>
+      sealRoute(workflowStatusRoute) ~>
       check {
       status === OK
       responseAs[WorkflowExecution] === WorkflowExecution(Some("f00ba4"), Map("para1" -> WorkflowParameter("v1"), "p2" -> WorkflowParameter("v2")), "workflow_id", "callback", Some("RUNNING"))

--- a/src/test/scala/org/broadinstitute/dsde/snoop/SnoopApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/snoop/SnoopApiServiceSpec.scala
@@ -15,7 +15,7 @@ import spray.testkit.ScalatestRouteTest
 import scala.concurrent.Future
 import spray.routing.RequestContext
 
-class SnoopApiServiceSpec extends FlatSpec with BaseSnoopApiService with WorkflowExecutionApiService with ScalatestRouteTest with Matchers {
+class SnoopApiServiceSpec extends FlatSpec with RootSnoopApiService with WorkflowExecutionApiService with ScalatestRouteTest with Matchers {
   def actorRefFactory = system
 
   val executionServiceHandler: RequestContext => WorkflowExecutionService = ZamboniWorkflowExecutionService(MockZamboniApi, "test")


### PR DESCRIPTION
Added swagger annotations to SnoopApiService and SnoopApiFormats. Had to stop using the ~ operator to chain routes together, because swagger needs a separate variable for each route, so it has something to hang the annotations on.