### PR TITLE
Dsdees 13 report job results

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ libraryDependencies ++= {
     "mysql" % "mysql-connector-java" % "5.1.12",
     "org.hsqldb" % "hsqldb" % "2.3.2",
     "com.gettyimages"     %%  "spray-swagger" % "0.5.0",
+    "com.google.apis" % "google-api-services-storage" % "v1-rev30-1.20.0",
     "io.spray"            %%  "spray-testkit" % sprayV  % "test",
     "com.typesafe.akka"   %%  "akka-testkit"  % akkaV   % "test",
     "org.scalatest"       %%  "scalatest"     % "2.2.4" % "test",

--- a/src/main/database/liquibase.changelog.xml
+++ b/src/main/database/liquibase.changelog.xml
@@ -14,8 +14,8 @@
         <comment>Create table</comment>
 
         <createTable tableName="SUBMISSION">
-            <column name="ID" autoIncrement="true" type="int">
-                <constraints primaryKey="true" nullable="false"/>
+            <column name="ID" type="varchar(36)">
+               <constraints nullable="false"/>
             </column>
             <column name="SUBMISSION_ID" type="varchar(255)">
                 <constraints nullable="false"/>
@@ -30,6 +30,7 @@
             </column>
         </createTable>
 
+        <addPrimaryKey tableName="SUBMISSION" constraintName="PK_SUBMISSION" columnNames="ID"/>
         <createIndex indexName="SUBMISSION_BY_SUBMISSIONID_IDX" tableName="SUBMISSION" unique="false">
             <column name="SUBMISSION_ID"/>
         </createIndex>

--- a/src/main/scala/org/broadinstitute/dsde/snoop/dataaccess/SnoopSubmissionController.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/dataaccess/SnoopSubmissionController.scala
@@ -18,11 +18,26 @@ object SnoopSubmissionController {
 class SnoopSubmissionController(database: () => Database, slickDriver: String) {
   val dataAccess = new DataAccess(slickDriver)
 
-  def createSubmission(workflowId: String, callbackUri: String, status: String) : Submission = {
+  def createSubmission(id: String, submissionId: String, callbackUri: String, status: String) : Submission = {
     database() withTransaction {
       implicit session =>
-        val submission = dataAccess.insertSubmission(Submission(workflowId, Option(new Timestamp(System.currentTimeMillis())), null, callbackUri, status))
+        val submission = dataAccess.insertSubmission(id, submissionId, callbackUri, status)
         submission
+    }
+  }
+
+  def getSubmission(id: String) : Submission = {
+    database() withTransaction {
+      implicit session =>
+        val submission = dataAccess.getSubmissionById(id)
+        submission
+    }
+  }
+
+  def updateSubmissionStatus(id: String, status: String) : Unit = {
+    database() withTransaction {
+      implicit session =>
+        dataAccess.updateSubmission(id, status)
     }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/snoop/dataaccess/SubmissionComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/dataaccess/SubmissionComponent.scala
@@ -4,54 +4,48 @@ import java.sql.Timestamp
 
 import org.broadinstitute.dsde.snoop.model.Submission
 
-
 trait SubmissionComponent {
   this: DriverComponent =>
   import driver.simple._
 
   class Submissions(tag: Tag) extends Table[Submission](tag, "SUBMISSION") {
-    def id = column[Int]("ID", O.PrimaryKey, O.AutoInc)
     def submissionId = column[String]("SUBMISSION_ID")
     def submissionDate = column[Timestamp]("SUBMISSION_DATE")
     def modifiedDate = column[Timestamp]("MODIFIED_DATE")
     def callbackUri = column[String]("CALLBACK_URI")
     def status = column[String]("STATUS")
+    def id = column[String]("ID", O.PrimaryKey)
 
-    override def * = (submissionId, submissionDate.?, modifiedDate.?, callbackUri, status, id.?) <> (Submission.tupled, Submission.unapply)
+    override def * = (id, submissionId, submissionDate.?, modifiedDate.?, callbackUri, status) <> (Submission.tupled, Submission.unapply)
   }
 
   val submissions = TableQuery[Submissions]
   val submissionsCompiled = Compiled(submissions)
 
-  private val submissionsAutoInc = submissionsCompiled returning submissions.map(_.id) into {
-    case (s, id) => s.copy(id = Option(id))
-  }
-  //private val autoInc = submissions.map(s => (s.submissionId, s.submissionDate, s.modifiedDate, s.callbackUri, s.status)) returning submissions.map(_.id)
-
-  def insertSubmission(submission: Submission)(implicit session: Session): Submission = {
-    //submissions.insert(submission)
-    //val id = autoInc.insert(submission.submissionId, submission.submissionDate, submission.modifiedDate, submission.callbackUri, submission.status)
-    //submission.copy(id = id)
-    submissionsAutoInc.insert(submission)
+  def insertSubmission(id: String, submissionId: String, callbackUri: String, status: String)(implicit session: Session): Submission = {
+    val submission = Submission(id, submissionId, Option(new Timestamp(System.currentTimeMillis())),
+                                null, callbackUri, status)
+    submissionsCompiled += submission
+    submission
   }
 
-  private val submissionsBySubmissionId = Compiled(
-    (submissionId: Column[String]) => for {
+  private val submissionsById = Compiled(
+    (id: Column[String]) => for {
       submission <- submissions
-      if submission.submissionId === submissionId
+      if submission.id === id
     } yield submission)
 
-  private val submissionsBySubmissionIdModified = Compiled(
-    (submissionId: Column[String]) => for {
+  private val submissionsByIdModified = Compiled(
+    (id: Column[String]) => for {
       submission <- submissions
-      if submission.submissionId === submissionId
+      if submission.id === id
     } yield (submission.status, submission.modifiedDate))
 
-  def updateSubmission(submissionId: String, status: String)(implicit session: Session) {
-    submissionsBySubmissionIdModified(submissionId).update(status, new Timestamp(System.currentTimeMillis()))
+  def updateSubmission(id: String, status: String)(implicit session: Session) {
+    submissionsByIdModified(id).update(status, new Timestamp(System.currentTimeMillis()))
   }
 
-  def getSubmissionBySubmissionId(submissionId: String)(implicit session: Session): Submission = {
-    submissionsBySubmissionId(submissionId).first
+  def getSubmissionById(id: String)(implicit session: Session): Submission = {
+    submissionsById(id).first
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/snoop/model/Submission.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/model/Submission.scala
@@ -7,10 +7,10 @@ import java.sql.Timestamp
  */
 case class Submission
 (
+  id: String,
   submissionId: String,
   submissionDate: Option[Timestamp] = None,
   modifiedDate: Option[Timestamp] = None,
   callbackUri: String,
-  status: String,
-  id: Option[Int] = None
+  status: String
 )

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/AnalysisCallbackHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/AnalysisCallbackHandler.scala
@@ -1,0 +1,41 @@
+package org.broadinstitute.dsde.snoop.ws
+
+import akka.actor.ActorSystem
+import org.broadinstitute.dsde.snoop.model.Submission
+import spray.client.pipelining._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * Created by plin on 4/1/15.
+ */
+object AnalysisCallbackHandler extends DefaultJsonProtocol {
+  case class AnalysesOutput(files: Map[String, String])
+  case class AnalysesOutputResponse(id: String, input: List[String], metadata: Map[String, String], files: Map[String, String])
+
+  implicit val AnalysesOutputFormat = jsonFormat1(AnalysesOutput)
+  implicit val AnalysesOutputResponseFormat = jsonFormat4(AnalysesOutputResponse)
+}
+
+import AnalysisCallbackHandler._
+
+trait AnalysisCallbackHandler {
+  def putOutputs(submission: Submission, outputs: Map[String, String]): AnalysesOutputResponse
+}
+
+case class StandardAnalysisCallbackHandler()(implicit val system: ActorSystem) extends AnalysisCallbackHandler {
+  import system.dispatcher
+
+  override def putOutputs(submission: Submission, outputs: Map[String, String]): AnalysesOutputResponse = {
+    val pipeline = addHeader("X-Force-Location", "true") ~> sendReceive ~> unmarshal[AnalysesOutputResponse]
+
+    val future = pipeline {
+      Post(submission.callbackUri, AnalysesOutput(outputs))
+    }
+
+    Await.result(future, 1 minutes)
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiFormats.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiFormats.scala
@@ -14,14 +14,14 @@ object WorkflowParameter {
 
 @ApiModel(value = "Start Workflow / Workflow Status Response")
 case class WorkflowExecution(
-    @(ApiModelProperty@field)(required = false, value = "The id of the workflow execution. Required for all but POST requests.")
+    @(ApiModelProperty@field)(required = false, value = "The uuid of the workflow execution. Required for all but POST requests.")
     id: Option[String], 
     @(ApiModelProperty@field)(required = true, value = "The workflow parameters. Values may be Strings or Lists of Strings.")
-    workflowParameters: Map[String, WorkflowParameter],
+    workflowParameters: Map[String, WorkflowParameter] = Map.empty,
     @(ApiModelProperty@field)(required = true, value = "The workflow id to run.")
-    workflowId: String, 
+    workflowId: String = "",
     @(ApiModelProperty@field)(required = true, value = "The callback uri. This URI will be POSTed to when the workflow execution completes.")
-    callbackUri: String,
+    callbackUri: String = "",
     @(ApiModelProperty@field)(required = false, value = "The workflow status.")
     status: Option[String])
 

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiService.scala
@@ -1,24 +1,36 @@
 package org.broadinstitute.dsde.snoop
 
-import akka.actor.{ActorRefFactory, Props, Actor}
-import com.typesafe.config.Config
+import org.broadinstitute.dsde.snoop.model.Submission
+
+import scala.collection.JavaConversions._
+import java.io.File
+import java.net.URI
+import java.util.{Collections, UUID}
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.http.{HttpRequest, HttpBackOffUnsuccessfulResponseHandler, HttpResponse}
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.util.ExponentialBackOff.Builder
+import com.google.api.services.storage.Storage
+import com.google.api.services.storage.model.{StorageObject, Objects}
 import org.broadinstitute.dsde.snoop.dataaccess.SnoopSubmissionController
 import org.broadinstitute.dsde.snoop.ws.PerRequest.RequestComplete
 import spray.http.StatusCodes
-import spray.httpx.SprayJsonSupport
-import spray.routing._
-import spray.json._
-import spray.http.MediaTypes._
-import spray.httpx.marshalling.ToResponseMarshallable.isMarshallable
-import spray.routing.Directive.pimpApply
-import org.broadinstitute.dsde.snoop.ws._
+import akka.actor.{Actor, ActorRefFactory, Props}
 import akka.event.Logging
+import com.gettyimages.spray.swagger.SwaggerHttpService
 import com.wordnik.swagger.annotations._
 import com.wordnik.swagger.model.ApiInfo
+import org.broadinstitute.dsde.snoop.ws._
+import spray.http.MediaTypes._
+import spray.httpx.SprayJsonSupport
+import spray.routing.Directive.pimpApply
+import spray.routing._
+
+import scala.annotation.tailrec
 import scala.reflect.runtime.universe._
-import com.gettyimages.spray.swagger.SwaggerHttpService
-import java.io.File
-import com.typesafe.config.{Config, ConfigFactory}
+import scala.util.matching._
 
 object SnoopApiServiceActor {
   def props(executionServiceConstructor: () => WorkflowExecutionService, swaggerService: SwaggerService): Props = {
@@ -146,30 +158,126 @@ object WorkflowExecutionService {
 
 trait WorkflowExecutionService extends Actor {
   val snoopSubmissionController: SnoopSubmissionController
+  val callbackHandler: AnalysisCallbackHandler
+  val gcsSandboxBucket: String
+  val gcsSandboxKeyPrefix: String
+  val outputRepository: OutputRepository
 
   implicit val system = context.system
   val log = Logging(system, getClass)
 
+  val succeeded = "SUCCEEDED"
+
+  val outputPatternsByType: Map[String, String] = Map(
+    ("vcf" -> raw".+\.vcf"),
+    ("bam" -> raw".+\.bam")
+  )
+
+  def submissionSandbox(submissionId: String) = s"gs://$gcsSandboxBucket/$gcsSandboxKeyPrefix/$submissionId"
 
   override def receive = {
     case WorkflowExecutionService.WorkflowStart(workflowExecution, securityToken) =>
-      val response = start(workflowExecution, securityToken)
-      snoopSubmissionController.createSubmission(workflowExecution.workflowId, workflowExecution.callbackUri, response.status.getOrElse(throw new SnoopException("status missing in response")))
-      context.parent ! RequestComplete(StatusCodes.Created, response)
+      val id = UUID.randomUUID().toString
+      val submissionId = start(workflowExecution.copy(id = Option(id)), securityToken, submissionSandbox(id))
+      snoopSubmissionController.createSubmission(id, submissionId, workflowExecution.callbackUri, "SUBMITTED")
+      context.parent ! RequestComplete(StatusCodes.Created, workflowExecution.copy(id=Option(id), status = Option("SUBMITTED")))
 
     case WorkflowExecutionService.WorkflowStatus(id, securityToken) =>
-      val response = status(id, securityToken)
-      context.parent ! response
+      val statusVal = status(id, securityToken)
+      if (statusVal == succeeded) {
+        val submission = snoopSubmissionController.getSubmission(id)
+        if (submission.status != succeeded) {
+          callbackHandler.putOutputs(submission, locateOutputs(submission))
+          snoopSubmissionController.updateSubmissionStatus(id, statusVal)
+        }
+      }
+      context.parent ! WorkflowExecution(id=Option(id), status=Option(statusVal))
   }
 
   /**
    * Starts a workflow execution, emits response directly to requestContext which should include
    * the id of the workflow execution
+   *
+   * @return the submission id in the underlying workflow engine
    */
-  def start(workflowExecution: WorkflowExecution, securityToken: String): WorkflowExecution
+  def start(workflowExecution: WorkflowExecution, securityToken: String, submissionSandbox: String): String
   
   /**
    * Gets status of a workflow execution, emits response directly to requestContext
+   *
+   * @return status
    */
-  def status(id: String, securityToken: String): WorkflowExecution
+  def status(id: String, securityToken: String): String
+
+  def locateOutputs(submission: Submission): Map[String, String] = {
+    val sandbox = submissionSandbox(submission.id)
+    val outputs = outputRepository.listOutputs(gcsSandboxBucket, gcsSandboxKeyPrefix)
+
+    val results = for (
+      output <- outputs;
+      outputTypePattern <- outputPatternsByType;
+      if (output.matches(outputTypePattern._2))
+    ) yield (outputTypePattern._1 -> output)
+
+    results.toMap
+  }
+
+}
+
+trait OutputRepository {
+  def listOutputs(bucket: String, keyPrefix: String): Seq[String]
+}
+
+case class GcsOutputRepository(googleEmail: String, p12FilePath: File) extends OutputRepository {
+  import scala.collection.JavaConversions._
+
+  private val STORAGE_SCOPE = "https://www.googleapis.com/auth/devstorage.read_write"
+  private val JSON_FACTORY: JacksonFactory = JacksonFactory.getDefaultInstance
+  private val credential: GoogleCredential = new GoogleCredential.Builder()
+    .setTransport(GoogleNetHttpTransport.newTrustedTransport)
+    .setJsonFactory(JSON_FACTORY)
+    .setServiceAccountId(googleEmail)
+    .setServiceAccountScopes(Collections.singleton(STORAGE_SCOPE))
+    .setServiceAccountPrivateKeyFromP12File(p12FilePath)
+    .build
+
+  private val storage = new Storage.Builder(GoogleNetHttpTransport.newTrustedTransport, JSON_FACTORY, credential)
+    .setApplicationName("snoop")
+    .build
+
+  def listOutputs(bucket: String, keyPrefix: String): Seq[String] = {
+    val list = storage.objects.list(bucket)
+    list.setPrefix(keyPrefix)
+    list.setMaxResults(500L)
+
+    @tailrec
+    def iteratePages(soFar: Seq[String]): Seq[String] = {
+      val objects = executeWithBackOff(list.buildHttpRequest, list.getResponseClass)
+      val fileObjects: Seq[StorageObject] = Option(objects.getItems: Seq[StorageObject]).getOrElse(Seq.empty[StorageObject])
+      val results = for (fileObject <- fileObjects) yield { fileObject.getName }
+      if (objects.getNextPageToken == null) {
+        soFar ++ results
+      } else {
+        iteratePages(soFar ++ results)
+      }
+    }
+
+    iteratePages(Vector.empty)
+  }
+
+  val backOffBuilder = new Builder()
+    .setInitialIntervalMillis(100)
+    .setMaxIntervalMillis(1000)
+    .setMultiplier(2.5)
+
+  private def executeWithBackOff(r: HttpRequest): HttpResponse = {
+    val handler: HttpBackOffUnsuccessfulResponseHandler = new HttpBackOffUnsuccessfulResponseHandler(backOffBuilder.build)
+    handler.setBackOffRequired(HttpBackOffUnsuccessfulResponseHandler.BackOffRequired.ON_SERVER_ERROR)
+    r.setUnsuccessfulResponseHandler(handler)
+    return r.execute
+  }
+
+  private def executeWithBackOff[T](r: HttpRequest, clazz: Class[T]): T = {
+    return executeWithBackOff(r).parseAs(clazz)
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/snoop/GcsOutputRepositorySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/snoop/GcsOutputRepositorySpec.scala
@@ -1,0 +1,21 @@
+package org.broadinstitute.dsde.snoop
+
+import java.io.File
+
+import org.scalatest.{Matchers, FlatSpec}
+
+import scala.collection.immutable.Vector
+
+/**
+ * Created by dvoet on 4/5/15.
+ */
+class GcsOutputRepositorySpec extends FlatSpec with Matchers {
+  // ignored because travis does not have credentials
+  ignore should "list correct files" in {
+    val outputRepository = GcsOutputRepository("806222273987-s85bmsenu8ipjjgaj1jq4nna60ql1l1u@developer.gserviceaccount.com", new File("/Users/dvoet/.snoop/dsde-79e6ca4ff051.p12"))
+
+    val results = outputRepository.listOutputs("broad-dsde-dev-private", "snoop-unit-test")
+
+    assertResult(Vector("snoop-unit-test/", "snoop-unit-test/bar.txt", "snoop-unit-test/foo.txt", "snoop-unit-test/splat/", "snoop-unit-test/splat/bar.txt", "snoop-unit-test/splat/foo.txt")) { results.sorted }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/snoop/SnoopControllerSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/snoop/SnoopControllerSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.snoop
 
 import java.sql.Timestamp
+import java.util.UUID
 
 import org.broadinstitute.dsde.snoop.dataaccess.SnoopSubmissionController
 import org.broadinstitute.dsde.snoop.model.Submission
@@ -20,10 +21,10 @@ class SnoopControllerSpec extends SnoopDatabaseSpec {
 
       TestDatabase.db withTransaction {
         implicit session => {
-          val sInsert = da.insertSubmission(Submission("f00ba4", Option(new Timestamp(System.currentTimeMillis())), null, "gs://test_location", "Submitted"))
-          val sSelect = da.getSubmissionBySubmissionId("f00ba4")
+          val id = UUID.randomUUID.toString
+          val sInsert = snoopSubmissionController.createSubmission(id, "f00ba4", "gs://test_location", "Submitted")
+          val sSelect = da.getSubmissionById(id)
 
-          sInsert.id shouldNot be(empty)
           sSelect.submissionId should be(sInsert.submissionId)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/snoop/TestDatabase.scala
+++ b/src/test/scala/org/broadinstitute/dsde/snoop/TestDatabase.scala
@@ -39,8 +39,8 @@ object TestDatabase {
     val connectionConstructor = connectionClass.getConstructor(classOf[Connection])
     val conn: DatabaseConnection = connectionConstructor.newInstance(holdingConnection).asInstanceOf[DatabaseConnection]
     liquibase = new Liquibase(DatabaseConfig.liquibaseChangeLog, resourceAccessor, conn)
-    //liquibase.dropAll()
-    //ChangeLogHistoryServiceFactory.getInstance().resetAll()
+    liquibase.dropAll()
+    ChangeLogHistoryServiceFactory.getInstance().resetAll()
     liquibase.update(contexts)
     conn.close()
   }


### PR DESCRIPTION
Do not merge this PR, it serves as a point for discussion/review.

Since the table structure has changed, we need to drop and recreate the table manually.  After dropping the table in a sql client, run the following liquibase command to recreate table.

liquibase --classpath=/path-to-mysql.jar --username=snoop --password=**** --changeLogFile=src/main/database/liquibase.root.xml --driver=com.mysql.jdbc.Driver --url="find in snoop.conf” update

the path to mysql jar on my machine is /Users/plin/.ivy2/cache/mysql/mysql-connector-java/jars/mysql-connector-java-5.1.25.jar. Make sure you set the env variable JAVA_TOOL_OPTIONS before running the command, see connect with SSL at https://broadinstitute.atlassian.net/wiki/display/DSDEV/Liquibase+DB+Maintenance
