### PR TITLE
added CORS support

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/snoop/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/Boot.scala
@@ -80,8 +80,9 @@ object Boot extends App {
         swaggerConfig.getString("license"),
         swaggerConfig.getString("licenseUrl"))
       ))
+    def getSwaggerOrigin : String = swaggerConfig.getString("origin")
 
-    val service = system.actorOf(SnoopApiServiceActor.props(executionServiceConstructor, swaggerService), "snoop-service")
+    val service = system.actorOf(SnoopApiServiceActor.props(executionServiceConstructor, swaggerService, getSwaggerOrigin), "snoop-service")
 
     implicit val timeout = Timeout(5.seconds)
     // start a new HTTP server on port 8080 with our service actor as the handler

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/CORSDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/CORSDirectives.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.snoop.ws
 import java.io.File
 
 import com.typesafe.config.ConfigFactory
+import org.broadinstitute.dsde.snoop.SwaggerService
 import spray.http.HttpHeaders._
 import spray.http.HttpMethods._
 import spray.http._
@@ -11,43 +12,39 @@ import spray.routing._
  * https://gist.github.com/joseraya/176821d856b43b1cfe19
  * https://github.com/giftig/mediaman/blob/22b95a807f6e7bb64d695583f4b856588c223fc1/src/main/scala/com/programmingcentre/utils/utils/CorsSupport.scala
  */
-case class `Access-Control-Allow-Credentials`(allowed: Boolean) extends HttpHeader {
-  def name = "Access-Control-Allow-Credentials"
-  def lowercaseName = "access-control-allow-credentials"
-  def value = if(allowed) "true" else "false"
 
-  override def render[R <: Rendering](r: R): r.type = r ~~ allowed.toString
-}
-
-trait CORSDirectives {
+trait CorsDirectives {
   this: HttpService =>
 
-  val conf = ConfigFactory.parseFile(new File("/etc/snoop.conf"))
-  val allowOriginHost = conf.getConfig("swagger").getString("origin")
-  private val allowOriginHeader = `Access-Control-Allow-Origin`(SomeOrigins(Seq(allowOriginHost)))
+  //val conf = ConfigFactory.parseFile(new File("/etc/snoop.conf"))
+  //val allowOriginHost = conf.getConfig("swagger").getString("origin")
   private val allowHeaders = `Access-Control-Allow-Headers`("Origin, X-Requested-With,X-Auth-Token, Content-Type, Accept, Accept-Encoding, Accept-Language, Host, Referer, User-Agent, Set-Cookie")
   private val optionsCorsHeaders = List(
     allowHeaders,
     `Access-Control-Max-Age`(60 * 60 * 24 * 20))  // cache pre-flight response for 20 days)
   private val allowCredentialsHeader = `Access-Control-Allow-Credentials`(true)
 
-  def cors[T]: Directive0 = mapRequestContext { context => context.withRouteResponseHandling({
-    // If an OPTIONS request was rejected as 405, complete the request by responding with the
-    // defined CORS details and the allowed options grabbed from the rejection
-    case Rejected(reasons) if (
-      context.request.method == HttpMethods.OPTIONS &&
-        reasons.exists(_.isInstanceOf[MethodRejection])
-      ) => {
-      val allowedMethods = reasons.collect { case r: MethodRejection => r.supported }
-      context.complete(HttpResponse().withHeaders(
-        `Access-Control-Allow-Methods`(OPTIONS, allowedMethods :_*) ::
-          allowOriginHeader ::
-          optionsCorsHeaders
-      ))
+  def cors[T](swaggerOrgin: String) : Directive0 = {
+    val allowOriginHeader = `Access-Control-Allow-Origin`(SomeOrigins(Vector(swaggerOrgin)))
+
+    mapRequestContext { context => context.withRouteResponseHandling({
+      // If an OPTIONS request was rejected as 405, complete the request by responding with the
+      // defined CORS details and the allowed options grabbed from the rejection
+      case Rejected(reasons) if (
+        context.request.method == HttpMethods.OPTIONS &&
+          reasons.exists(_.isInstanceOf[MethodRejection])
+        ) => {
+        val allowedMethods = reasons.collect{ case r: MethodRejection => r.supported}
+        context.complete(HttpResponse().withHeaders(
+          `Access-Control-Allow-Methods`(OPTIONS, allowedMethods: _*) ::
+            allowOriginHeader ::
+            optionsCorsHeaders
+        ))
+      }
+    }).withHttpResponseHeadersMapped {
+      //added allowHeaders here to avoid error "Request header field Content-Type is not allowed by Access-Control-Allow-Headers"
+      headers => allowOriginHeader :: allowHeaders :: allowCredentialsHeader :: headers
     }
-  }).withHttpResponseHeadersMapped {
-    //added allowHeaders here to avoid error "Request header field Content-Type is not allowed by Access-Control-Allow-Headers"
-    headers => allowOriginHeader :: allowHeaders :: allowCredentialsHeader :: headers
-  }
+    }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/CORSDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/CORSDirectives.scala
@@ -1,0 +1,53 @@
+package org.broadinstitute.dsde.snoop.ws
+
+import java.io.File
+
+import com.typesafe.config.ConfigFactory
+import spray.http.HttpHeaders._
+import spray.http.HttpMethods._
+import spray.http._
+import spray.routing._
+/**
+ * https://gist.github.com/joseraya/176821d856b43b1cfe19
+ * https://github.com/giftig/mediaman/blob/22b95a807f6e7bb64d695583f4b856588c223fc1/src/main/scala/com/programmingcentre/utils/utils/CorsSupport.scala
+ */
+case class `Access-Control-Allow-Credentials`(allowed: Boolean) extends HttpHeader {
+  def name = "Access-Control-Allow-Credentials"
+  def lowercaseName = "access-control-allow-credentials"
+  def value = if(allowed) "true" else "false"
+
+  override def render[R <: Rendering](r: R): r.type = r ~~ allowed.toString
+}
+
+trait CORSDirectives {
+  this: HttpService =>
+
+  val conf = ConfigFactory.parseFile(new File("/etc/snoop.conf"))
+  val allowOriginHost = conf.getConfig("swagger").getString("origin")
+  private val allowOriginHeader = `Access-Control-Allow-Origin`(SomeOrigins(Seq(allowOriginHost)))
+  private val allowHeaders = `Access-Control-Allow-Headers`("Origin, X-Requested-With,X-Auth-Token, Content-Type, Accept, Accept-Encoding, Accept-Language, Host, Referer, User-Agent, Set-Cookie")
+  private val optionsCorsHeaders = List(
+    allowHeaders,
+    `Access-Control-Max-Age`(60 * 60 * 24 * 20))  // cache pre-flight response for 20 days)
+  private val allowCredentialsHeader = `Access-Control-Allow-Credentials`(true)
+
+  def cors[T]: Directive0 = mapRequestContext { context => context.withRouteResponseHandling({
+    // If an OPTIONS request was rejected as 405, complete the request by responding with the
+    // defined CORS details and the allowed options grabbed from the rejection
+    case Rejected(reasons) if (
+      context.request.method == HttpMethods.OPTIONS &&
+        reasons.exists(_.isInstanceOf[MethodRejection])
+      ) => {
+      val allowedMethods = reasons.collect { case r: MethodRejection => r.supported }
+      context.complete(HttpResponse().withHeaders(
+        `Access-Control-Allow-Methods`(OPTIONS, allowedMethods :_*) ::
+          allowOriginHeader ::
+          optionsCorsHeaders
+      ))
+    }
+  }).withHttpResponseHeadersMapped {
+    //added allowHeaders here to avoid error "Request header field Content-Type is not allowed by Access-Control-Allow-Headers"
+    headers => allowOriginHeader :: allowHeaders :: allowCredentialsHeader :: headers
+  }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiService.scala
@@ -29,8 +29,8 @@ import scala.annotation.tailrec
 import scala.reflect.runtime.universe._
 
 object SnoopApiServiceActor {
-  def props(executionServiceConstructor: () => WorkflowExecutionService, swaggerService: SwaggerService): Props = {
-    Props(new SnoopApiServiceActor(executionServiceConstructor, swaggerService))
+  def props(executionServiceConstructor: () => WorkflowExecutionService, swaggerService: SwaggerService, swaggerOrigin: String): Props = {
+    Props(new SnoopApiServiceActor(executionServiceConstructor, swaggerService, swaggerOrigin))
   }
 }
 
@@ -41,10 +41,10 @@ class SwaggerService(override val apiVersion: String,
                      override val apiTypes: Seq[Type],
                      override val apiInfo: Option[ApiInfo])(implicit val actorRefFactory: ActorRefFactory) extends SwaggerHttpService
 
-class SnoopApiServiceActor(executionServiceCtor: () => WorkflowExecutionService, swaggerService: SwaggerService) extends Actor with RootSnoopApiService with WorkflowExecutionApiService with CORSDirectives {
+class SnoopApiServiceActor(executionServiceCtor: () => WorkflowExecutionService, swaggerService: SwaggerService, swaggerOrigin: String) extends Actor with RootSnoopApiService with WorkflowExecutionApiService with CorsDirectives {
   implicit def executionContext = actorRefFactory.dispatcher
   def actorRefFactory = context
-  def possibleRoutes =  cors { baseRoute ~ workflowRoutes ~ swaggerService.routes }
+  def possibleRoutes =  cors(swaggerOrigin){ baseRoute ~ workflowRoutes ~ swaggerService.routes }
 
   def receive = runRoute(possibleRoutes)
   def apiTypes = Seq(typeOf[RootSnoopApiService], typeOf[WorkflowExecutionApiService])

--- a/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/snoop/ws/SnoopApiService.scala
@@ -1,36 +1,32 @@
 package org.broadinstitute.dsde.snoop
 
-import org.broadinstitute.dsde.snoop.model.Submission
-
-import scala.collection.JavaConversions._
 import java.io.File
-import java.net.URI
-import java.util.{NoSuchElementException, Collections, UUID}
+import java.util.{Collections, NoSuchElementException, UUID}
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-import com.google.api.client.http.{HttpRequest, HttpBackOffUnsuccessfulResponseHandler, HttpResponse}
-import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.client.util.ExponentialBackOff.Builder
-import com.google.api.services.storage.Storage
-import com.google.api.services.storage.model.{StorageObject, Objects}
-import org.broadinstitute.dsde.snoop.dataaccess.SnoopSubmissionController
-import org.broadinstitute.dsde.snoop.ws.PerRequest.RequestComplete
-import spray.http.StatusCodes
 import akka.actor.{Actor, ActorRefFactory, Props}
 import akka.event.Logging
 import com.gettyimages.spray.swagger.SwaggerHttpService
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.http.{HttpBackOffUnsuccessfulResponseHandler, HttpRequest, HttpResponse}
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.util.ExponentialBackOff.Builder
+import com.google.api.services.storage.Storage
+import com.google.api.services.storage.model.StorageObject
 import com.wordnik.swagger.annotations._
 import com.wordnik.swagger.model.ApiInfo
+import org.broadinstitute.dsde.snoop.dataaccess.SnoopSubmissionController
+import org.broadinstitute.dsde.snoop.model.Submission
+import org.broadinstitute.dsde.snoop.ws.PerRequest.RequestComplete
 import org.broadinstitute.dsde.snoop.ws._
 import spray.http.MediaTypes._
+import spray.http.StatusCodes
 import spray.httpx.SprayJsonSupport
 import spray.routing.Directive.pimpApply
 import spray.routing._
 
 import scala.annotation.tailrec
 import scala.reflect.runtime.universe._
-import scala.util.matching._
 
 object SnoopApiServiceActor {
   def props(executionServiceConstructor: () => WorkflowExecutionService, swaggerService: SwaggerService): Props = {
@@ -45,10 +41,10 @@ class SwaggerService(override val apiVersion: String,
                      override val apiTypes: Seq[Type],
                      override val apiInfo: Option[ApiInfo])(implicit val actorRefFactory: ActorRefFactory) extends SwaggerHttpService
 
-class SnoopApiServiceActor(executionServiceCtor: () => WorkflowExecutionService, swaggerService: SwaggerService) extends Actor with RootSnoopApiService with WorkflowExecutionApiService {
+class SnoopApiServiceActor(executionServiceCtor: () => WorkflowExecutionService, swaggerService: SwaggerService) extends Actor with RootSnoopApiService with WorkflowExecutionApiService with CORSDirectives {
   implicit def executionContext = actorRefFactory.dispatcher
   def actorRefFactory = context
-  def possibleRoutes = baseRoute ~ workflowRoutes ~ swaggerService.routes 
+  def possibleRoutes =  cors { baseRoute ~ workflowRoutes ~ swaggerService.routes }
 
   def receive = runRoute(possibleRoutes)
   def apiTypes = Seq(typeOf[RootSnoopApiService], typeOf[WorkflowExecutionApiService])
@@ -92,8 +88,8 @@ trait RootSnoopApiService extends HttpService {
 // this trait defines our service behavior independently from the service actor
 @Api(value = "workflowExecutions", description = "Snoop Workflow Execution API", position = 1)
 trait WorkflowExecutionApiService extends HttpService with PerRequestCreator {
-  import WorkflowExecutionJsonSupport._
-  import SprayJsonSupport._
+  import org.broadinstitute.dsde.snoop.ws.WorkflowExecutionJsonSupport._
+  import spray.httpx.SprayJsonSupport._
 
   def executionServiceConstructor(): WorkflowExecutionService
 
@@ -108,7 +104,7 @@ trait WorkflowExecutionApiService extends HttpService with PerRequestCreator {
     new ApiResponse(code = 200, message = "Successful Request"),
     new ApiResponse(code = 500, message = "Snoop Internal Error")
   ))  
-  def startWorkflowRoute = 
+  def startWorkflowRoute =
     cookie("iPlanetDirectoryPro") { securityTokenCookie =>
       val securityToken = securityTokenCookie.content
       path("workflowExecutions") {


### PR DESCRIPTION
This is for using snoop swagger UI from another server (e.g. apollo-api).  You will need to add 
origin = "http://apollo-api:8000" to the swagger section in snoop.conf.

I believe this should work.  However due to the hardship setting up a proxy server locally, testing was limited.  

According to this post https://github.com/swagger-api/swagger-ui/issues/343, the apollo-api server may need to add useJQuery:true and xhr.withCredentials=true when initializing SwaggerUI in order to send along the cookie, eg :

new SwaggerUi({
                url: "/api-docs",
                dom_id: "swagger-ui-container",
                useJQuery: true,
                beforeSend: function(xhr){
                    xhr.withCredentials = true;
                } 
             ...
